### PR TITLE
Nullify non-valid transitions on disable_autoresetting

### DIFF
--- a/stoix/configs/system/ppo/ff_ppo.yaml
+++ b/stoix/configs/system/ppo/ff_ppo.yaml
@@ -19,5 +19,5 @@ standardize_advantages: True # Whether to standardize the advantages.
 kl_penalty_coef: 3.0 # KL penalty coefficient for PPO updates if using PPO Penalty.
 redistribute_reward: False # Whether to redistribute episodic rewards across all transitions
 redistribute_reward_implicit: False # Whether to implicitly redistribute episodic rewards across all transitions (scales advantage by (T-t)/T)
-disable_autoreset: True # Whether to disable autoresetting environments on env termination during rollout
+disable_autoreset: True # Whether to disable Stoix-level autoresetting of environments (on env termination during rollout)
 use_mc_returns_ae: True # Whether to use Monte-Carlo returns for advantage estimation

--- a/stoix/configs/system/ppo/ff_ppo.yaml
+++ b/stoix/configs/system/ppo/ff_ppo.yaml
@@ -20,4 +20,4 @@ kl_penalty_coef: 3.0 # KL penalty coefficient for PPO updates if using PPO Penal
 redistribute_reward: False # Whether to redistribute episodic rewards across all transitions
 redistribute_reward_implicit: False # Whether to implicitly redistribute episodic rewards across all transitions (scales advantage by (T-t)/T)
 disable_autoreset: True # Whether to disable Stoix-level autoresetting of environments (on env termination during rollout)
-use_mc_returns_ae: True # Whether to use Monte-Carlo returns for advantage estimation
+use_mc_returns_ae: False # Whether to use Monte-Carlo returns for advantage estimation

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -506,9 +506,13 @@ def run_experiment(_config: DictConfig) -> float:
     ), "Reward redistribution assumes `gamma=1.0` and `gae_lambda=1.0`."
     assert (
         (
-            config.system.redistribute_reward
-            or config.system.redistribute_reward_implicit
-        ) and config.system.get("disable_autoreset", False) and config.env.kwargs.get("disable_autoreset", False)
+            not config.system.redistribute_reward
+            and not config.system.redistribute_reward_implicit
+        )
+        or (
+            config.system.get("disable_autoreset", False)
+            and config.env.kwargs.get("disable_autoreset", False)
+        )
     ), """Reward redistribution currently only supports single episodes per rollout. Technically,
     only partial rollouts are problematic. If you need multi-episode support, please open an
     issue at https://github.com/p-doom/reward-redistribution."""

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -130,7 +130,7 @@ def get_learner_fn(
 
         # DISTRIBUTE EPISODIC REWARD ACROSS ALL TRANSITIONS
         if config.system.redistribute_reward:
-            # WARNING: This only works for max_steps (of env) == rollout_length
+            # WARNING: This only works for single episodes per rollout
             # WARNING: This only works for the (sparse) episodic reward setting
             # and will silently corrupt the reward structure otherwise
 

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -509,9 +509,9 @@ def run_experiment(_config: DictConfig) -> float:
             config.system.redistribute_reward
             or config.system.redistribute_reward_implicit
         ) and config.system.get("disable_autoreset", False) and config.env.kwargs.get("disable_autoreset", False)
-    ), "Reward redistribution currently only supports single episodes per rollout. Technically, \
-    only partial rollouts are problematic. If you need multi-episode support, please open an \
-    issue at https://github.com/p-doom/reward-redistribution."
+    ), """Reward redistribution currently only supports single episodes per rollout. Technically,
+    only partial rollouts are problematic. If you need multi-episode support, please open an
+    issue at https://github.com/p-doom/reward-redistribution."""
 
     # Create the environments for train and eval.
     env, eval_env = environments.make(config=config)


### PR DESCRIPTION
If autoresetting is disabled (note: for navix environments it must be disabled both Stoix-level as well as navix-level), we need to nullify the contributions of transitions that happened after the episode ended. This is due to the way we disable navix-level autoresetting: We change navix' behaviour such that `env.step` doesn't reset the environment on a terminal state, but always steps the environment. When navix steps at a terminal state, the terminal reward is emitted again.

Other environment might not need this explicit nullification.