### PR TITLE
fix: episode_mask adheres to truncation and done-ness & dones&truncat…

### DIFF
--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -1,5 +1,4 @@
 import copy
-from math import trunc
 import time
 from typing import Any, Dict, Tuple
 

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -1,4 +1,5 @@
 import copy
+from math import trunc
 import time
 from typing import Any, Dict, Tuple
 
@@ -128,38 +129,49 @@ def get_learner_fn(
             _env_step, learner_state, None, config.system.rollout_length
         )
 
-        # For each trajectory (axis=1), find the first done index along time dimension (axis=0)
+        trajectory_length = traj_batch.done.shape[0] # type: ignore
+
+        # For each trajectory (axis=1), find the episode ending (first of either done_- or truncation_index along time dimension (axis=0))
         done_indices = jnp.argmax(traj_batch.done, axis=0)  # shape: (num_trajectories,)
+        done_indices = jnp.where(jnp.any(traj_batch.done, axis=0), done_indices, trajectory_length)
+        truncation_indices = jnp.argmax(traj_batch.truncated, axis=0) # shape: (num_trajectories,)
+        truncation_indices = jnp.where(jnp.any(traj_batch.truncated, axis=0), truncation_indices, trajectory_length)
+        episode_termination_indices = jnp.minimum(done_indices, truncation_indices)
+
         # Create mask for non-valid transitions (time > done_index for each trajectory)
         time_indices = jnp.arange(traj_batch.done.shape[0])[:, jnp.newaxis]  # (num_timesteps, 1)
-        post_episode_mask = time_indices > done_indices[jnp.newaxis, :]  # Mask for steps after episode ends
+        post_episode_mask = time_indices > episode_termination_indices[jnp.newaxis, :]  # Mask for steps after episode ends
+        episode_mask = jnp.logical_not(post_episode_mask)  # (num_timesteps, num_trajectories)
 
         # If autoresetting is disabled, we nullify dones, values, rewards, and log_probs after end of episode
+        # FIXME: This is only navix-level. Assuming that most environments do not autoreset, we should make system.disable_autoreset
+        # the ground-truth
         if config.env.kwargs.get("disable_autoreset", False):
+            episode_dones = jnp.where(episode_mask, traj_batch.done, False)
+            new_dones = jnp.where(jnp.any(episode_dones, axis=0), time_indices >= done_indices[jnp.newaxis, :], jnp.array(False))
+            new_truncations = jnp.where(jnp.any(traj_batch.truncated, axis=0), time_indices >= truncation_indices[jnp.newaxis, :], jnp.array(False))
             traj_batch = traj_batch._replace(
-                done=jnp.where(post_episode_mask, False, traj_batch.done),
+                done=new_dones,
+                truncated=new_truncations,
                 value=jnp.where(post_episode_mask, 0.0, traj_batch.value),
                 reward=jnp.where(post_episode_mask, 0.0, traj_batch.reward),
                 log_prob=jnp.where(post_episode_mask, 0.0, traj_batch.log_prob),
             )
 
-        # DISTRIBUTE EPISODIC REWARD ACROSS ALL TRANSITIONS
         if config.system.redistribute_reward:
+            # DISTRIBUTE EPISODIC REWARD ACROSS ALL TRANSITIONS
             # WARNING: This only works for single episodes per rollout
             # WARNING: This only works for the (sparse) episodic reward setting
             # and will silently corrupt the reward structure otherwise
 
-            # Episode lengths are index+1 (for trajectories with done=True)
-            episode_lengths = done_indices + 1  # shape: (num_trajectories,)
+            # Episode lengths are index+1
+            episode_lengths = episode_termination_indices + 1  # shape: (num_trajectories,)
             
-            # Extract episodic reward (reward at done step for each trajectory)
-            episodic_reward = traj_batch.reward[done_indices, jnp.arange(traj_batch.reward.shape[1])]  # shape: (num_trajectories,)
+            # Extract episodic reward (reward at last step for each trajectory)
+            episodic_reward = traj_batch.reward[episode_termination_indices, jnp.arange(traj_batch.reward.shape[1])]  # shape: (num_trajectories,)
             
             # Compute normalized reward per trajectory
             normalized_reward = episodic_reward / episode_lengths  # shape: (num_trajectories,)
-            
-            # Create mask for valid transitions (time <= done_index for each trajectory)
-            episode_mask = jnp.logical_not(post_episode_mask)  # (num_timesteps, num_trajectories)
             
             # Broadcast normalized reward across time steps and apply mask
             new_reward = jnp.where(
@@ -174,7 +186,7 @@ def get_learner_fn(
         params, opt_states, key, env_state, last_timestep = learner_state
 
         if config.env.kwargs.get("disable_autoreset", False):
-            last_val = jnp.zeros_like(done_indices)
+            last_val = jnp.zeros_like(episode_termination_indices)
         else:
             last_val = critic_apply_fn(params.critic_params, last_timestep.observation)
 

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -154,7 +154,6 @@ def get_learner_fn(
                 truncated=new_truncations,
                 value=jnp.where(post_episode_mask, 0.0, traj_batch.value),
                 reward=jnp.where(post_episode_mask, 0.0, traj_batch.reward),
-                log_prob=jnp.where(post_episode_mask, 0.0, traj_batch.log_prob),
             )
 
         if config.system.redistribute_reward:


### PR DESCRIPTION
…ed set correctly

- `episode_mask` now correctly adheres to truncation and early termination
- We want to adhere to default behaviour while ensuring that `env.step`s after episode termination do not contribute to later calculations. `done`s and `truncated`s are now set to the following: If `done` or `truncated` is set before episode ending, all following `done`s and `truncated`s are set to `True` respectively. 