### PR TITLE
fix: mask non-episodic transitions during actor and value loss calcul…

### DIFF
--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -232,10 +232,10 @@ def get_learner_fn(
                     # CALCULATE ACTOR LOSS
                     loss_actor = jax.lax.cond(
                         config.env.kwargs.get("disable_autoreset", False),
-                        ppo_masked_clip_loss(
+                        lambda: ppo_masked_clip_loss(
                             log_prob, traj_batch.log_prob, gae, config.system.clip_eps, episode_mask
                         ),
-                        ppo_clip_loss(
+                        lambda: ppo_clip_loss(
                             log_prob, traj_batch.log_prob, gae, config.system.clip_eps
                         ),
                     )
@@ -261,10 +261,10 @@ def get_learner_fn(
                     # CALCULATE VALUE LOSS
                     value_loss = jax.lax.cond(
                         config.env.kwargs.get("disable_autoreset", False),
-                        clipped_masked_value_loss(
+                        lambda: clipped_masked_value_loss(
                             value, traj_batch.value, targets, config.system.clip_eps, episode_mask
                         ),
-                        clipped_value_loss(
+                        lambda: clipped_value_loss(
                             value, traj_batch.value, targets, config.system.clip_eps
                         )
                     )

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -35,7 +35,7 @@ from stoix.utils.jax_utils import (
     unreplicate_n_dims,
 )
 from stoix.utils.logger import LogEvent, StoixLogger
-from stoix.utils.loss import clipped_value_loss, ppo_clip_loss
+from stoix.utils.loss import clipped_value_loss, clipped_masked_value_loss, ppo_clip_loss, ppo_masked_clip_loss
 from stoix.utils.multistep import batch_truncated_generalized_advantage_estimation, batch_truncated_monte_carlo_return_advantage
 from stoix.utils.total_timestep_checker import check_total_timesteps
 from stoix.utils.training import make_learning_rate
@@ -230,9 +230,16 @@ def get_learner_fn(
                     log_prob = actor_policy.log_prob(traj_batch.action)
 
                     # CALCULATE ACTOR LOSS
-                    loss_actor = ppo_clip_loss(
-                        log_prob, traj_batch.log_prob, gae, config.system.clip_eps
+                    loss_actor = jax.lax.cond(
+                        config.env.kwargs.get("disable_autoreset", False),
+                        ppo_masked_clip_loss(
+                            log_prob, traj_batch.log_prob, gae, config.system.clip_eps, episode_mask
+                        ),
+                        ppo_clip_loss(
+                            log_prob, traj_batch.log_prob, gae, config.system.clip_eps
+                        ),
                     )
+                    # FIXME: Entropy calculation should not use post-episode transitions
                     entropy = actor_policy.entropy().mean()
 
                     total_loss_actor = loss_actor - config.system.ent_coef * entropy
@@ -252,8 +259,14 @@ def get_learner_fn(
                     value = critic_apply_fn(critic_params, traj_batch.obs)
 
                     # CALCULATE VALUE LOSS
-                    value_loss = clipped_value_loss(
-                        value, traj_batch.value, targets, config.system.clip_eps
+                    value_loss = jax.lax.cond(
+                        config.env.kwargs.get("disable_autoreset", False),
+                        clipped_masked_value_loss(
+                            value, traj_batch.value, targets, config.system.clip_eps, episode_mask
+                        ),
+                        clipped_value_loss(
+                            value, traj_batch.value, targets, config.system.clip_eps
+                        )
                     )
 
                     critic_total_loss = config.system.vf_coef * value_loss

--- a/stoix/utils/loss.py
+++ b/stoix/utils/loss.py
@@ -32,6 +32,27 @@ def ppo_clip_loss(
     return loss_actor
 
 
+def ppo_masked_clip_loss(
+    pi_log_prob_t: chex.Array, b_pi_log_prob_t: chex.Array, gae_t: chex.Array, epsilon: float, episode_mask: chex.Array
+) -> chex.Array:
+    ratio = jnp.exp(pi_log_prob_t - b_pi_log_prob_t)
+    loss_actor1 = ratio * gae_t
+    loss_actor2 = (
+        jnp.clip(
+            ratio,
+            1.0 - epsilon,
+            1.0 + epsilon,
+        )
+        * gae_t
+    )
+    loss_actor = -jnp.minimum(loss_actor1, loss_actor2)
+
+    masked_loss_actor = loss_actor * episode_mask
+
+    loss_actor = masked_loss_actor.mean()
+    return loss_actor
+
+
 def ppo_penalty_loss(
     pi_log_prob_t: chex.Array,
     b_pi_log_prob_t: chex.Array,
@@ -74,6 +95,23 @@ def clipped_value_loss(
     value_losses = jnp.square(pred_value_t - targets_t)
     value_losses_clipped = jnp.square(value_pred_clipped - targets_t)
     value_loss = 0.5 * jnp.maximum(value_losses, value_losses_clipped).mean()
+
+    return value_loss
+
+
+def clipped_masked_value_loss(
+    pred_value_t: chex.Array, behavior_value_t: chex.Array, targets_t: chex.Array, epsilon: float, episode_mask: chex.Array
+) -> chex.Array:
+    value_pred_clipped = behavior_value_t + (pred_value_t - behavior_value_t).clip(
+        -epsilon, epsilon
+    )
+    value_losses = jnp.square(pred_value_t - targets_t)
+    value_losses_clipped = jnp.square(value_pred_clipped - targets_t)
+
+    masked_value_losses = value_losses * episode_mask
+    masked_value_losses_clipped = value_losses_clipped * episode_mask
+
+    value_loss = 0.5 * jnp.maximum(masked_value_losses, masked_value_losses_clipped).mean()
 
     return value_loss
 


### PR DESCRIPTION
…ations

Currently, post-episodic transitions influence the actor and value loss calculations. This PR nullifies those transitions using `episode_mask`.