### PR TITLE
fix: mask non-episodic transitions during actor and value loss calcul…

### DIFF
--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -217,12 +217,13 @@ def get_learner_fn(
 
                 # UNPACK TRAIN STATE AND BATCH INFO
                 params, opt_states = train_state
-                traj_batch, advantages, targets = batch_info
+                traj_batch, advantages, targets, episode_mask = batch_info
 
                 def _actor_loss_fn(
                     actor_params: FrozenDict,
                     traj_batch: PPOTransition,
                     gae: chex.Array,
+                    episode_mask: chex.Array
                 ) -> Tuple:
                     """Calculate the actor loss."""
                     # RERUN NETWORK
@@ -253,6 +254,7 @@ def get_learner_fn(
                     critic_params: FrozenDict,
                     traj_batch: PPOTransition,
                     targets: chex.Array,
+                    episode_mask: chex.Array
                 ) -> Tuple:
                     """Calculate the critic loss."""
                     # RERUN NETWORK
@@ -278,13 +280,13 @@ def get_learner_fn(
                 # CALCULATE ACTOR LOSS
                 actor_grad_fn = jax.grad(_actor_loss_fn, has_aux=True)
                 actor_grads, actor_loss_info = actor_grad_fn(
-                    params.actor_params, traj_batch, advantages
+                    params.actor_params, traj_batch, advantages, episode_mask # TODO mihir check
                 )
 
                 # CALCULATE CRITIC LOSS
                 critic_grad_fn = jax.grad(_critic_loss_fn, has_aux=True)
                 critic_grads, critic_loss_info = critic_grad_fn(
-                    params.critic_params, traj_batch, targets
+                    params.critic_params, traj_batch, targets, episode_mask # TODO mihir check
                 )
 
                 # Compute the parallel mean (pmean) over the batch.
@@ -336,7 +338,7 @@ def get_learner_fn(
             # SHUFFLE MINIBATCHES
             batch_size = config.system.rollout_length * config.arch.num_envs
             permutation = jax.random.permutation(shuffle_key, batch_size)
-            batch = (traj_batch, advantages, targets)
+            batch = (traj_batch, advantages, targets, episode_mask) # TODO mihir check
             batch = jax.tree_util.tree_map(lambda x: merge_leading_dims(x, 2), batch)
             shuffled_batch = jax.tree_util.tree_map(
                 lambda x: jnp.take(x, permutation, axis=0), batch

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -232,10 +232,10 @@ def get_learner_fn(
                     # CALCULATE ACTOR LOSS
                     loss_actor = jax.lax.cond(
                         config.env.kwargs.get("disable_autoreset", False),
-                        ppo_masked_clip_loss(
+                        lambda: ppo_masked_clip_loss(
                             log_prob, traj_batch.log_prob, gae, config.system.clip_eps, episode_mask
                         ),
-                        ppo_clip_loss(
+                        lambda: ppo_clip_loss(
                             log_prob, traj_batch.log_prob, gae, config.system.clip_eps
                         ),
                     )
@@ -261,10 +261,10 @@ def get_learner_fn(
                     # CALCULATE VALUE LOSS
                     value_loss = jax.lax.cond(
                         config.env.kwargs.get("disable_autoreset", False),
-                        clipped_masked_value_loss(
+                        lambda: clipped_masked_value_loss(
                             value, traj_batch.value, targets, config.system.clip_eps, episode_mask
                         ),
-                        clipped_value_loss(
+                        lambda: clipped_value_loss(
                             value, traj_batch.value, targets, config.system.clip_eps
                         )
                     )

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -109,7 +109,7 @@ def get_learner_fn(
             return learner_state, transition
 
         # Explicitly reset the environment if autoresetting is disabled
-        if config.env.kwargs.get("disable_autoreset", False):
+        if config.env.kwargs.disable_autoreset:
             key, *env_keys = jax.random.split(
                 learner_state.key, config.arch.num_envs + 1
             )
@@ -145,7 +145,7 @@ def get_learner_fn(
         # If autoresetting is disabled, we nullify dones, values, rewards, and log_probs after end of episode
         # FIXME: This is only navix-level. Assuming that most environments do not autoreset, we should make system.disable_autoreset
         # the ground-truth
-        if config.env.kwargs.get("disable_autoreset", False):
+        if config.env.kwargs.disable_autoreset:
             episode_dones = jnp.where(episode_mask, traj_batch.done, False)
             new_dones = jnp.where(jnp.any(episode_dones, axis=0), time_indices >= done_indices[jnp.newaxis, :], jnp.array(False))
             new_truncations = jnp.where(jnp.any(traj_batch.truncated, axis=0), time_indices >= truncation_indices[jnp.newaxis, :], jnp.array(False))
@@ -183,7 +183,7 @@ def get_learner_fn(
         # CALCULATE ADVANTAGE
         params, opt_states, key, env_state, last_timestep = learner_state
 
-        if config.env.kwargs.get("disable_autoreset", False):
+        if config.env.kwargs.disable_autoreset:
             last_val = jnp.zeros_like(episode_termination_indices)
         else:
             last_val = critic_apply_fn(params.critic_params, last_timestep.observation)
@@ -232,7 +232,7 @@ def get_learner_fn(
 
                     # CALCULATE ACTOR LOSS
                     loss_actor = jax.lax.cond(
-                        config.env.kwargs.get("disable_autoreset", False),
+                        config.env.kwargs.disable_autoreset,
                         lambda: ppo_masked_clip_loss(
                             log_prob, traj_batch.log_prob, gae, config.system.clip_eps, ep_mask
                         ),
@@ -262,7 +262,7 @@ def get_learner_fn(
 
                     # CALCULATE VALUE LOSS
                     value_loss = jax.lax.cond(
-                        config.env.kwargs.get("disable_autoreset", False),
+                        config.env.kwargs.disable_autoreset,
                         lambda: clipped_masked_value_loss(
                             value, traj_batch.value, targets, config.system.clip_eps, ep_mask
                         ),

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -35,7 +35,7 @@ from stoix.utils.jax_utils import (
     unreplicate_n_dims,
 )
 from stoix.utils.logger import LogEvent, StoixLogger
-from stoix.utils.loss import clipped_value_loss, ppo_clip_loss
+from stoix.utils.loss import clipped_value_loss, clipped_masked_value_loss, ppo_clip_loss, ppo_masked_clip_loss
 from stoix.utils.multistep import batch_truncated_generalized_advantage_estimation, batch_truncated_monte_carlo_return_advantage
 from stoix.utils.total_timestep_checker import check_total_timesteps
 from stoix.utils.training import make_learning_rate
@@ -230,9 +230,16 @@ def get_learner_fn(
                     log_prob = actor_policy.log_prob(traj_batch.action)
 
                     # CALCULATE ACTOR LOSS
-                    loss_actor = ppo_clip_loss(
-                        log_prob, traj_batch.log_prob, gae, config.system.clip_eps
+                    loss_actor = jax.lax.cond(
+                        config.env.kwargs.get("disable_autoreset", False),
+                        ppo_masked_clip_loss(
+                            log_prob, traj_batch.log_prob, gae, config.system.clip_eps, episode_mask
+                        ),
+                        ppo_clip_loss(
+                            log_prob, traj_batch.log_prob, gae, config.system.clip_eps
+                        ),
                     )
+                    # FIXME: Entropy calculation should not use post-episode transitions
                     entropy = actor_policy.entropy().mean()
 
                     total_loss_actor = loss_actor - config.system.ent_coef * entropy
@@ -252,8 +259,14 @@ def get_learner_fn(
                     value = critic_apply_fn(critic_params, traj_batch.obs)
 
                     # CALCULATE VALUE LOSS
-                    value_loss = clipped_value_loss(
-                        value, traj_batch.value, targets, config.system.clip_eps
+                    value_loss = jax.lax.cond(
+                        config.env.kwargs.get("disable_autoreset", False),
+                        clipped_masked_value_loss(
+                            value, traj_batch.value, targets, config.system.clip_eps, episode_mask
+                        ),
+                        clipped_value_loss(
+                            value, traj_batch.value, targets, config.system.clip_eps
+                        )
                     )
 
                     critic_total_loss = config.system.vf_coef * value_loss

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -217,13 +217,13 @@ def get_learner_fn(
 
                 # UNPACK TRAIN STATE AND BATCH INFO
                 params, opt_states = train_state
-                traj_batch, advantages, targets, episode_mask = batch_info
+                traj_batch, advantages, targets, episode_mask_minibatch = batch_info
 
                 def _actor_loss_fn(
                     actor_params: FrozenDict,
                     traj_batch: PPOTransition,
                     gae: chex.Array,
-                    episode_mask: chex.Array
+                    ep_mask: chex.Array
                 ) -> Tuple:
                     """Calculate the actor loss."""
                     # RERUN NETWORK
@@ -234,7 +234,7 @@ def get_learner_fn(
                     loss_actor = jax.lax.cond(
                         config.env.kwargs.get("disable_autoreset", False),
                         lambda: ppo_masked_clip_loss(
-                            log_prob, traj_batch.log_prob, gae, config.system.clip_eps, episode_mask
+                            log_prob, traj_batch.log_prob, gae, config.system.clip_eps, ep_mask
                         ),
                         lambda: ppo_clip_loss(
                             log_prob, traj_batch.log_prob, gae, config.system.clip_eps
@@ -254,7 +254,7 @@ def get_learner_fn(
                     critic_params: FrozenDict,
                     traj_batch: PPOTransition,
                     targets: chex.Array,
-                    episode_mask: chex.Array
+                    ep_mask: chex.Array
                 ) -> Tuple:
                     """Calculate the critic loss."""
                     # RERUN NETWORK
@@ -264,7 +264,7 @@ def get_learner_fn(
                     value_loss = jax.lax.cond(
                         config.env.kwargs.get("disable_autoreset", False),
                         lambda: clipped_masked_value_loss(
-                            value, traj_batch.value, targets, config.system.clip_eps, episode_mask
+                            value, traj_batch.value, targets, config.system.clip_eps, ep_mask
                         ),
                         lambda: clipped_value_loss(
                             value, traj_batch.value, targets, config.system.clip_eps
@@ -280,13 +280,13 @@ def get_learner_fn(
                 # CALCULATE ACTOR LOSS
                 actor_grad_fn = jax.grad(_actor_loss_fn, has_aux=True)
                 actor_grads, actor_loss_info = actor_grad_fn(
-                    params.actor_params, traj_batch, advantages, episode_mask 
+                    params.actor_params, traj_batch, advantages, episode_mask_minibatch 
                 )
 
                 # CALCULATE CRITIC LOSS
                 critic_grad_fn = jax.grad(_critic_loss_fn, has_aux=True)
                 critic_grads, critic_loss_info = critic_grad_fn(
-                    params.critic_params, traj_batch, targets, episode_mask 
+                    params.critic_params, traj_batch, targets, episode_mask_minibatch
                 )
 
                 # Compute the parallel mean (pmean) over the batch.
@@ -332,13 +332,13 @@ def get_learner_fn(
                 }
                 return (new_params, new_opt_state), loss_info
 
-            params, opt_states, traj_batch, advantages, targets, episode_mask, key = update_state
+            params, opt_states, traj_batch, advantages, targets, episode_mask_epoch, key = update_state
             key, shuffle_key = jax.random.split(key)
 
             # SHUFFLE MINIBATCHES
             batch_size = config.system.rollout_length * config.arch.num_envs
             permutation = jax.random.permutation(shuffle_key, batch_size)
-            batch = (traj_batch, advantages, targets, episode_mask) 
+            batch = (traj_batch, advantages, targets, episode_mask_epoch) 
             batch = jax.tree_util.tree_map(lambda x: merge_leading_dims(x, 2), batch)
             shuffled_batch = jax.tree_util.tree_map(
                 lambda x: jnp.take(x, permutation, axis=0), batch
@@ -353,7 +353,7 @@ def get_learner_fn(
                 _update_minibatch, (params, opt_states), minibatches
             )
 
-            update_state = (params, opt_states, traj_batch, advantages, targets, episode_mask, key)
+            update_state = (params, opt_states, traj_batch, advantages, targets, episode_mask_epoch, key)
             return update_state, loss_info
 
         update_state = (params, opt_states, traj_batch, advantages, targets, episode_mask, key)

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -280,13 +280,13 @@ def get_learner_fn(
                 # CALCULATE ACTOR LOSS
                 actor_grad_fn = jax.grad(_actor_loss_fn, has_aux=True)
                 actor_grads, actor_loss_info = actor_grad_fn(
-                    params.actor_params, traj_batch, advantages, episode_mask # TODO mihir check
+                    params.actor_params, traj_batch, advantages, episode_mask 
                 )
 
                 # CALCULATE CRITIC LOSS
                 critic_grad_fn = jax.grad(_critic_loss_fn, has_aux=True)
                 critic_grads, critic_loss_info = critic_grad_fn(
-                    params.critic_params, traj_batch, targets, episode_mask # TODO mihir check
+                    params.critic_params, traj_batch, targets, episode_mask 
                 )
 
                 # Compute the parallel mean (pmean) over the batch.
@@ -332,13 +332,13 @@ def get_learner_fn(
                 }
                 return (new_params, new_opt_state), loss_info
 
-            params, opt_states, traj_batch, advantages, targets, key = update_state
+            params, opt_states, traj_batch, advantages, targets, episode_mask, key = update_state
             key, shuffle_key = jax.random.split(key)
 
             # SHUFFLE MINIBATCHES
             batch_size = config.system.rollout_length * config.arch.num_envs
             permutation = jax.random.permutation(shuffle_key, batch_size)
-            batch = (traj_batch, advantages, targets, episode_mask) # TODO mihir check
+            batch = (traj_batch, advantages, targets, episode_mask) 
             batch = jax.tree_util.tree_map(lambda x: merge_leading_dims(x, 2), batch)
             shuffled_batch = jax.tree_util.tree_map(
                 lambda x: jnp.take(x, permutation, axis=0), batch
@@ -353,17 +353,17 @@ def get_learner_fn(
                 _update_minibatch, (params, opt_states), minibatches
             )
 
-            update_state = (params, opt_states, traj_batch, advantages, targets, key)
+            update_state = (params, opt_states, traj_batch, advantages, targets, episode_mask, key)
             return update_state, loss_info
 
-        update_state = (params, opt_states, traj_batch, advantages, targets, key)
+        update_state = (params, opt_states, traj_batch, advantages, targets, episode_mask, key)
 
         # UPDATE EPOCHS
         update_state, loss_info = jax.lax.scan(
             _update_epoch, update_state, None, config.system.epochs
         )
 
-        params, opt_states, traj_batch, advantages, targets, key = update_state
+        params, opt_states, traj_batch, advantages, targets, episode_mask, key = update_state
         learner_state = OnPolicyLearnerState(params, opt_states, key, env_state, last_timestep)
         metric = traj_batch.info
         return learner_state, (metric, loss_info)

--- a/stoix/utils/loss.py
+++ b/stoix/utils/loss.py
@@ -32,6 +32,27 @@ def ppo_clip_loss(
     return loss_actor
 
 
+def ppo_masked_clip_loss(
+    pi_log_prob_t: chex.Array, b_pi_log_prob_t: chex.Array, gae_t: chex.Array, epsilon: float, episode_mask: chex.Array
+) -> chex.Array:
+    ratio = jnp.exp(pi_log_prob_t - b_pi_log_prob_t)
+    loss_actor1 = ratio * gae_t
+    loss_actor2 = (
+        jnp.clip(
+            ratio,
+            1.0 - epsilon,
+            1.0 + epsilon,
+        )
+        * gae_t
+    )
+    loss_actor = -jnp.minimum(loss_actor1, loss_actor2)
+
+    masked_loss_actor = loss_actor * episode_mask
+
+    loss_actor = masked_loss_actor.mean()
+    return loss_actor
+
+
 def ppo_penalty_loss(
     pi_log_prob_t: chex.Array,
     b_pi_log_prob_t: chex.Array,
@@ -74,6 +95,23 @@ def clipped_value_loss(
     value_losses = jnp.square(pred_value_t - targets_t)
     value_losses_clipped = jnp.square(value_pred_clipped - targets_t)
     value_loss = 0.5 * jnp.maximum(value_losses, value_losses_clipped).mean()
+
+    return value_loss
+
+
+def clipped_masked_value_loss(
+    pred_value_t: chex.Array, behavior_value_t: chex.Array, targets_t: chex.Array, epsilon: float, episode_mask: chex.Array
+) -> chex.Array:
+    value_pred_clipped = behavior_value_t + (pred_value_t - behavior_value_t).clip(
+        -epsilon, epsilon
+    )
+    value_losses = jnp.square(pred_value_t - targets_t)
+    value_losses_clipped = jnp.square(value_pred_clipped - targets_t)
+
+    masked_value_losses = value_losses * episode_mask
+    masked_value_losses_clipped = value_losses_clipped * episode_mask
+
+    value_loss = 0.5 * jnp.maximum(masked_value_losses, masked_value_losses_clipped).mean()
 
     return value_loss
 


### PR DESCRIPTION
…ations

Currently, post-episodic transitions influence the actor and value loss calculations. This PR nullifies those transitions using `episode_mask`.
