### PR TITLE
fix: last delta & advantage getting nullified

### DIFF
--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -547,6 +547,10 @@ def run_experiment(_config: DictConfig) -> float:
     assert (
             config.system.disable_autoreset == config.env.kwargs.disable_autoreset
     ), "Autoresetting must be disabled both at Stoix- and navix-level."
+    assert (
+        config.system.disable_autoreset and config.env.kwargsdisable_autoreset
+    ), """Autoresetting is not supported any more due to bugs in the upstream implementation. Further
+    information is available at https://github.com/p-doom/reward-redistribution/pull/10."""
 
     # Create the environments for train and eval.
     env, eval_env = environments.make(config=config)

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -148,7 +148,7 @@ def get_learner_fn(
         if config.env.kwargs.get("disable_autoreset", False):
             episode_dones = jnp.where(episode_mask, traj_batch.done, False)
             new_dones = jnp.where(jnp.any(episode_dones, axis=0), time_indices >= done_indices[jnp.newaxis, :], jnp.array(False))
-            new_truncations = jnp.where(jnp.any(traj_batch.truncated, axis=0), time_indices >= truncation_indices[jnp.newaxis, :], jnp.array(False))
+            new_truncations = jnp.where(jnp.any(traj_batch.truncated, axis=0), time_indices > truncation_indices[jnp.newaxis, :], jnp.array(False))
             traj_batch = traj_batch._replace(
                 done=new_dones,
                 truncated=new_truncations,

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -109,7 +109,7 @@ def get_learner_fn(
             return learner_state, transition
 
         # Explicitly reset the environment if autoresetting is disabled
-        if config.env.kwargs.get("disable_autoreset", False):
+        if config.env.kwargs.disable_autoreset:
             key, *env_keys = jax.random.split(
                 learner_state.key, config.arch.num_envs + 1
             )
@@ -145,7 +145,7 @@ def get_learner_fn(
         # If autoresetting is disabled, we nullify dones, values, rewards, and log_probs after end of episode
         # FIXME: This is only navix-level. Assuming that most environments do not autoreset, we should make system.disable_autoreset
         # the ground-truth
-        if config.env.kwargs.get("disable_autoreset", False):
+        if config.env.kwargs.disable_autoreset:
             episode_dones = jnp.where(episode_mask, traj_batch.done, False)
             new_dones = jnp.where(jnp.any(episode_dones, axis=0), time_indices >= done_indices[jnp.newaxis, :], jnp.array(False))
             # NOTE: We use `>` instead of `>=` since we would otherwise nullify the last delta of the episode in the GAE calculation
@@ -184,7 +184,7 @@ def get_learner_fn(
         # CALCULATE ADVANTAGE
         params, opt_states, key, env_state, last_timestep = learner_state
 
-        if config.env.kwargs.get("disable_autoreset", False):
+        if config.env.kwargs.disable_autoreset:
             last_val = jnp.zeros_like(episode_termination_indices)
         else:
             last_val = critic_apply_fn(params.critic_params, last_timestep.observation)
@@ -538,14 +538,14 @@ def run_experiment(_config: DictConfig) -> float:
             and not config.system.redistribute_reward_implicit
         )
         or (
-            config.system.get("disable_autoreset", False)
-            and config.env.kwargs.get("disable_autoreset", False)
+            config.system.disable_autoreset
+            and config.env.kwargs.disable_autoreset
         )
     ), """Reward redistribution currently only supports single episodes per rollout. Technically,
     only partial rollouts are problematic. If you need multi-episode support, please open an
     issue at https://github.com/p-doom/reward-redistribution."""
     assert (
-            config.system.get("disable_autoreset", False) == config.env.kwargs.get("disable_autoreset", False)
+            config.system.disable_autoreset == config.env.kwargs.disable_autoreset
     ), "Autoresetting must be disabled both at Stoix- and navix-level."
 
     # Create the environments for train and eval.

--- a/stoix/systems/ppo/anakin/ff_ppo.py
+++ b/stoix/systems/ppo/anakin/ff_ppo.py
@@ -148,6 +148,7 @@ def get_learner_fn(
         if config.env.kwargs.get("disable_autoreset", False):
             episode_dones = jnp.where(episode_mask, traj_batch.done, False)
             new_dones = jnp.where(jnp.any(episode_dones, axis=0), time_indices >= done_indices[jnp.newaxis, :], jnp.array(False))
+            # NOTE: We use `>` instead of `>=` since we would otherwise nullify the last delta of the episode in the GAE calculation
             new_truncations = jnp.where(jnp.any(traj_batch.truncated, axis=0), time_indices > truncation_indices[jnp.newaxis, :], jnp.array(False))
             traj_batch = traj_batch._replace(
                 done=new_dones,


### PR DESCRIPTION
Stoix' PPO implementation has a bug where an episode's last `delta` and `advantage` get nullified on truncation because `truncation_mask` does not contain the transition where `truncation_flag` is set (which is the last transition of a truncated trajectory).

We fix this for `disable_autoreset=True` by ensuring that `traj_batch.truncations` is only nonzero after the episode has ended.

Please note that this fix only works for `disable_autoreset=True`. Without disabling autoresetting (i.e. the setting of the upstream repository), the fix becomes less straightforward. Additionally in the autoresetting setting, there is a second bug, where the `deltas` are calculated using cross-boundary values (i.e. value of a state that is not from the current episode) on trajectories that are not truncated, but terminated due to the goal being achieved.