### PR TITLE
feat: disable autoresetting for gymnax

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ envpool
 flashbax @ git+https://github.com/instadeepai/flashbax
 flax
 gymnasium
-gymnax>=0.0.6
+gymnax @ git+https://github.com/p-doom/gymnax
 huggingface_hub
 hydra-core==1.3.2
 id-marl-eval @ git+https://github.com/EdanToledo/marl-eval

--- a/stoix/configs/env/gymnax/acrobot.yaml
+++ b/stoix/configs/env/gymnax/acrobot.yaml
@@ -5,7 +5,9 @@ scenario:
   name: Acrobot-v1
   task_name: acrobot
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/configs/env/gymnax/asterix.yaml
+++ b/stoix/configs/env/gymnax/asterix.yaml
@@ -5,7 +5,9 @@ scenario:
   name: Asterix-MinAtar
   task_name: asterix
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/configs/env/gymnax/breakout.yaml
+++ b/stoix/configs/env/gymnax/breakout.yaml
@@ -5,7 +5,9 @@ scenario:
   name: Breakout-MinAtar
   task_name: breakout
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/configs/env/gymnax/cartpole.yaml
+++ b/stoix/configs/env/gymnax/cartpole.yaml
@@ -5,7 +5,9 @@ scenario:
   name: CartPole-v1
   task_name: cartpole # For logging purposes.
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/configs/env/gymnax/freeway.yaml
+++ b/stoix/configs/env/gymnax/freeway.yaml
@@ -5,7 +5,9 @@ scenario:
   name: Freeway-MinAtar
   task_name: freeway
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/configs/env/gymnax/mountain_car.yaml
+++ b/stoix/configs/env/gymnax/mountain_car.yaml
@@ -5,7 +5,9 @@ scenario:
   name: MountainCar-v0
   task_name: mountain_car
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/configs/env/gymnax/mountain_car_continuous.yaml
+++ b/stoix/configs/env/gymnax/mountain_car_continuous.yaml
@@ -5,7 +5,9 @@ scenario:
   name: MountainCarContinuous-v0
   task_name: mountain_car_continuous
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/configs/env/gymnax/pendulum.yaml
+++ b/stoix/configs/env/gymnax/pendulum.yaml
@@ -5,7 +5,9 @@ scenario:
   name: Pendulum-v1
   task_name: pendulum
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/configs/env/gymnax/space_invaders.yaml
+++ b/stoix/configs/env/gymnax/space_invaders.yaml
@@ -5,7 +5,9 @@ scenario:
   name: SpaceInvaders-MinAtar
   task_name: space_invaders
 
-kwargs: {}
+kwargs: {
+  disable_autoreset: True,
+}
 
 # Defines the metric that will be used to evaluate the performance of the agent.
 # This metric is returned at the end of an experiment and can be used for hyperparameter tuning.

--- a/stoix/utils/make_env.py
+++ b/stoix/utils/make_env.py
@@ -97,7 +97,8 @@ def make_gymnax_env(env_name: str, config: DictConfig) -> Tuple[Environment, Env
     env = GymnaxWrapper(env, env_params)
     eval_env = GymnaxWrapper(eval_env, eval_env_params)
 
-    env = AutoResetWrapper(env, next_obs_in_extras=True)
+    if not config.system.disable_autoreset:
+        env = AutoResetWrapper(env, next_obs_in_extras=True)
     env = RecordEpisodeMetrics(env)
 
     return env, eval_env
@@ -367,8 +368,7 @@ def make_navix_env(env_name: str, config: DictConfig) -> Tuple[Environment, Envi
     env = NavixWrapper(env)
     eval_env = NavixWrapper(eval_env)
 
-    disable_autoreset = config.system.get("disable_autoreset", False)
-    if not disable_autoreset:
+    if not config.system.disable_autoreset:
         env = AutoResetWrapper(env, next_obs_in_extras=True)
     env = RecordEpisodeMetrics(env)
 


### PR DESCRIPTION
- We modify the gymnax library to optionally disable autoresetting via `env.kwargs.disable_autoreset=True`.
- We point to our custom gymnax library instead of the upstream one.
- We add the logic to disable autoresetting to `GymnaxWrapper`
- We disable gymnax-internal autoresetting per default by setting `env.kwargs.disable_autoreset=True` for all gymnax environments