### PR TITLE
feat: adhere to new gymnax api exposing termination and truncation (f…

### DIFF
--- a/stoix/wrappers/gymnax.py
+++ b/stoix/wrappers/gymnax.py
@@ -76,18 +76,21 @@ class GymnaxWrapper(Wrapper):
 
     def step(self, state: GymnaxEnvState, action: chex.Array) -> Tuple[GymnaxEnvState, TimeStep]:
         key, key_step = jax.random.split(state.key)
-        obs, gymnax_state, reward, done, _ = self._env.step(
+        obs, gymnax_state, reward, termination, truncation, _ = self._env.step(
             key_step, state.gymnax_env_state, action, self._env_params
         )
         state = GymnaxEnvState(
             key=key, gymnax_env_state=gymnax_state, step_count=state.step_count + 1
         )
 
+        discount = jnp.array(1.0 - termination, dtype=float)
+        final_step = jnp.logical_or(termination, truncation)
+
         timestep = TimeStep(
             observation=Observation(obs, self._legal_action_mask, state.step_count),
             reward=reward.astype(float),
-            discount=jnp.array(1.0 - done, dtype=float),
-            step_type=jax.lax.select(done, StepType.LAST, StepType.MID),
+            discount=discount,
+            step_type=jax.lax.select(final_step, StepType.LAST, StepType.MID),
             extras={},
         )
         return state, timestep


### PR DESCRIPTION
…ixes inconsistent Stoix-internal API)

This should fix the issues with the metric collection being wrong (e.g. before, the actor metrics were not being collected when using Stoix with gymnax, most likely due to https://github.com/EdanToledo/Stoix/issues/147)

Note that this fix only works for https://github.com/p-doom/gymnax/pull/2/ (so need to install https://github.com/p-doom/gymnax/commit/48cbe6629fd8c628b6966fd0fd62592cadd84aff)
